### PR TITLE
Get rid of Pandas DataFrames

### DIFF
--- a/pygsl_div.py
+++ b/pygsl_div.py
@@ -8,9 +8,7 @@ created by Florian Roessler and Lies Boelen
 
 import click
 import numpy as np
-import pandas as pd
 import scipy.stats as sc
-from functools import reduce
 
 
 def get_symbolised_ts(ts, b, L, min_per=1, max_per=99, state_space=None):
@@ -193,8 +191,8 @@ def gsl_div(original, model, weights='add-progressive',
               help='State space boundaries. Format example: "(0, 1)"',
               show_default=True)
 def main(original, model, weights, b, l, min_per, max_per, state_space):
-    original_ts = pd.read_csv(original).values.T
-    model_ts = pd.read_csv(model).values.T
+    original_ts = np.loadtxt(original, delimiter=',', skiprows=1, ndmin=2, unpack=True)
+    model_ts = np.loadtxt(model, delimiter=',', skiprows=1, ndmin=2, unpack=True)
     res = gsl_div(original_ts, model_ts, weights=weights, b=b, L=l,
                   min_per=min_per, max_per=max_per,
                   state_space=eval(state_space))

--- a/pygsl_div.py
+++ b/pygsl_div.py
@@ -53,6 +53,11 @@ def get_symbolised_ts(ts, b, L, min_per=1, max_per=99, state_space=None):
         cuts = np.linspace(min_p, max_p, b+1)
     else:
         cuts = np.linspace(state_space[0], state_space[1], b+1)
+
+    # make sure that no values fall outside the bins:
+    cuts[0] = -np.inf
+    cuts[-1] = np.inf
+
     # now we map the time series to the bins in the symbol space
     symbolised_ts = np.array([np.digitize(t, cuts) for t in ts])
     # to be able to deal with "words" or combination of symbols it is easier

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 scipy
 numpy
-pandas
 click


### PR DESCRIPTION
Built on #3, this will not fix any bugs, but instead get rid of the (usually slower) DataFrames in favor of more modern numpy functionalities, working on pure numpy arrays. It might well be that some of these numpy functions didn't even exist when this repository was created in 2018.